### PR TITLE
remove doiuse support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-hmre": "^1.1.1",
     "css-loader": "^0.26.1",
-    "doiuse": "^2.3.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "foundation-sites": "^6.3.0",

--- a/webpack/makeWebpackConfig.js
+++ b/webpack/makeWebpackConfig.js
@@ -2,7 +2,6 @@
 
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
-const doiuse = require('doiuse');
 const stylelint = require('stylelint');
 const reporter = require('postcss-reporter');
 const constants = require('./constants');
@@ -98,10 +97,6 @@ const makeWebpackConfig = (isDevelopment) => {
     },
     postcss: () => {
       return [
-        doiuse({
-          browsers: browserSupport,
-          onFeatureUsage: usage => console.log(usage.message) // eslint-disable-line
-        }),
         stylelint,
         reporter({ clearMessages: true }),
         autoprefixer({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,7 +1557,7 @@ doctrine@1.5.0, doctrine@^1.2.2:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doiuse@^2.3.0, doiuse@^2.4.1:
+doiuse@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/doiuse/-/doiuse-2.5.0.tgz#c7f156965d054bf4d699a4067af1cadbc7350b7c"
   dependencies:
@@ -3336,11 +3336,11 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.1.0, minimist@^1.1.0:
+minimist@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.0.tgz#cdf225e8898f840a258ded44fc91776770afdc93"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 


### PR DESCRIPTION
Issue #19

I did run "yarn remove doiuse", however doiuse is a dependency of stylelint so it still exists in yarn.lock.