### PR TITLE
Fix loading assets with sass sourcemaps

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,6 +10,6 @@ Glue.compose(Manifest, { relativeTo: __dirname }, (err, server) => {
 
   server.start((startErr) => {
     Hoek.assert(!startErr, startErr);
-    console.log(`Server started: ${server.info.uri}`); // eslint-disable-line
+    console.log(`Server started: http://${server.info.address}:${server.info.port}`); // eslint-disable-line
   });
 });

--- a/webpack/makeWebpackConfig.js
+++ b/webpack/makeWebpackConfig.js
@@ -56,11 +56,11 @@ const makeWebpackConfig = (isDevelopment) => {
     output: {
       filename: 'app.js',
       path: constants.DIST_DIR,
-      publicPath: '/static/'
+      publicPath: isDevelopment ? 'http://localhost:3000/static/' : '/static/'
     },
     assets: {
       noInfo: true,
-      publicPath: '/static/'
+      publicPath: isDevelopment ? 'http://localhost:3000/static/' : '/static/'
     },
     plugins,
     resolve: {

--- a/webpack/makeWebpackConfig.js
+++ b/webpack/makeWebpackConfig.js
@@ -56,11 +56,11 @@ const makeWebpackConfig = (isDevelopment) => {
     output: {
       filename: 'app.js',
       path: constants.DIST_DIR,
-      publicPath: isDevelopment ? 'http://localhost:3000/static/' : '/static/'
+      publicPath: isDevelopment ? 'http://0.0.0.0:3000/static/' : '/static/'
     },
     assets: {
       noInfo: true,
-      publicPath: isDevelopment ? 'http://localhost:3000/static/' : '/static/'
+      publicPath: isDevelopment ? 'http://0.0.0.0:3000/static/' : '/static/'
     },
     plugins,
     resolve: {


### PR DESCRIPTION
Resolves Issue #15 

This is not ideal, because we have to set an absolute public path. This would mean you can't access your local machine externally.

However, setting the public path dynamically means putting a hack in at run time.

Open to other ideas.